### PR TITLE
feat: min(), max(), mean()

### DIFF
--- a/gofluxbuilder.go
+++ b/gofluxbuilder.go
@@ -17,6 +17,9 @@ type Query struct {
 	From   Builder
 	Range  Builder
 	Filter Builder
+	Max    Builder
+	Min    Builder
+	Mean   Builder
 }
 
 // QueryBuilder is the persistent struct that allows us to hold the information
@@ -34,6 +37,9 @@ func NewGoFluxQueryBuilder() *QueryBuilder {
 		From:   FromBuilder{},
 		Range:  RangeBuilder{},
 		Filter: nil,
+		Max:    nil,
+		Min:    nil,
+		Mean:   nil,
 	}}
 }
 
@@ -52,6 +58,36 @@ func (q *QueryBuilder) Range(r Builder) *QueryBuilder {
 // Filter allows to define filters of flux query
 func (q *QueryBuilder) Filter(filter Builder) *QueryBuilder {
 	q.query.Filter = filter
+	return q
+}
+
+// Max allows to define max of flux query
+func (q *QueryBuilder) Max(max ...Builder) *QueryBuilder {
+	if len(max) == 0 {
+		q.query.Max = MaxBuilder{}
+		return q
+	}
+	q.query.Max = max[0]
+	return q
+}
+
+// Min allows to define max of flux query
+func (q *QueryBuilder) Min(min ...Builder) *QueryBuilder {
+	if len(min) == 0 {
+		q.query.Min = MinBuilder{}
+		return q
+	}
+	q.query.Min = min[0]
+	return q
+}
+
+// Mean allows to define max of flux query
+func (q *QueryBuilder) Mean(mean ...Builder) *QueryBuilder {
+	if len(mean) == 0 {
+		q.query.Mean = MeanBuilder{}
+		return q
+	}
+	q.query.Mean = mean[0]
 	return q
 }
 
@@ -88,6 +124,18 @@ func (q *QueryBuilder) Build() (string, error) {
 	if q.query.Filter != nil {
 		query += pipeGenerator()
 		query += q.query.Filter.Parse()
+	}
+	if q.query.Max != nil {
+		query += pipeGenerator()
+		query += q.query.Max.Parse()
+	}
+	if q.query.Min != nil {
+		query += pipeGenerator()
+		query += q.query.Min.Parse()
+	}
+	if q.query.Mean != nil {
+		query += pipeGenerator()
+		query += q.query.Mean.Parse()
 	}
 	return query, nil
 }

--- a/max_builder.go
+++ b/max_builder.go
@@ -1,0 +1,15 @@
+package gofluxbuilder
+
+type MaxBuilder struct {
+	Column string
+}
+
+// Validate is the validation impl of Builder for MaxBuilder
+func (f MaxBuilder) Validate() error {
+	return nil
+}
+
+// Parse is the parsing impl of Builder for MaxBuilder
+func (f MaxBuilder) Parse() string {
+	return commonGenerator("max", f)
+}

--- a/mean_builder.go
+++ b/mean_builder.go
@@ -1,0 +1,15 @@
+package gofluxbuilder
+
+type MeanBuilder struct {
+	Column string
+}
+
+// Validate is the validation impl of Builder for MeanBuilder
+func (f MeanBuilder) Validate() error {
+	return nil
+}
+
+// Parse is the parsing impl of Builder for MeanBuilder
+func (f MeanBuilder) Parse() string {
+	return commonGenerator("mean", f)
+}

--- a/min_builder.go
+++ b/min_builder.go
@@ -1,0 +1,15 @@
+package gofluxbuilder
+
+type MinBuilder struct {
+	Column string
+}
+
+// Validate is the validation impl of Builder for MinBuilder
+func (f MinBuilder) Validate() error {
+	return nil
+}
+
+// Parse is the parsing impl of Builder for MinBuilder
+func (f MinBuilder) Parse() string {
+	return commonGenerator("min", f)
+}


### PR DESCRIPTION
This PR adds the following builders and fixes #3 :

- `min()`
- `max()`
- `mean()`

All the above builders optionally support the `column: ""` field

The following builders can be used as below:

### Min Builder

```go
	result, error := gofluxbuilder.NewGoFluxQueryBuilder().From(
		gofluxbuilder.FromBuilder{Bucket: "birdy"}).Range(gofluxbuilder.
		RangeBuilder{Start: "-4y"}).Filter(gofluxbuilder.NewFilterBuilder().
		Equal("_measurement", "migration")).Min().Build()

	if error != nil {
		panic(error)
	}
	fmt.Println(result)
````

#### Result

```flux
from(bucket: "birdy", )
        |> range(start: -4y, )
        |> filter(fn: (r) => r._measurement == "migration")
        |> min()
```

### Max Builder

```go
	result, error := gofluxbuilder.NewGoFluxQueryBuilder().From(
		gofluxbuilder.FromBuilder{Bucket: "birdy"}).Range(gofluxbuilder.
		RangeBuilder{Start: "-4y"}).Filter(gofluxbuilder.NewFilterBuilder().
		Equal("_measurement", "migration")).Max().Build()

	if error != nil {
		panic(error)
	}
	fmt.Println(result)
````

#### Result

```flux
from(bucket: "birdy", )
        |> range(start: -4y, )
        |> filter(fn: (r) => r._measurement == "migration")
        |> max()
```

### Mean Builder

```go
	result, error := gofluxbuilder.NewGoFluxQueryBuilder().From(
		gofluxbuilder.FromBuilder{Bucket: "birdy"}).Range(gofluxbuilder.
		RangeBuilder{Start: "-4y"}).Filter(gofluxbuilder.NewFilterBuilder().
		Equal("_measurement", "migration")).Mean().Build()

	if error != nil {
		panic(error)
	}
	fmt.Println(result)
````

#### Result

```flux
from(bucket: "birdy", )
        |> range(start: -4y, )
        |> filter(fn: (r) => r._measurement == "migration")
        |> mean()
```