### PR TITLE
feat: sort(), limit() builders

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -4,6 +4,7 @@ const (
 	fromBuilderError     = "fromBuilderError"
 	rangeBuilderError    = "rangeBuilderError"
 	filterBuilderError   = "filterBuilderError"
+	limitBuilderError    = "limitBuilderError"
 	queryValidationError = "goFluxBuilder Validation Error"
 	queryRequestError    = "goFluxBuilder query request error: "
 )

--- a/generator.go
+++ b/generator.go
@@ -69,3 +69,30 @@ func commonGenerator(name string, data interface{}) string {
 	generator += ")"
 	return generator
 }
+
+func sortGenerator(data SortBuilder) string {
+	generator := "sort("
+	if len(data.Columns) > 0 {
+		generator += "columns: ["
+		for i, value := range data.Columns {
+			if i == len(data.Columns)-1 {
+				generator += fmt.Sprintf("\"%v\"", value)
+				break
+			}
+			generator += fmt.Sprintf("\"%v\", ", value)
+		}
+		generator += "], "
+		generator += fmt.Sprintf("desc: %t", data.Desc)
+	}
+	generator += ")"
+	return generator
+}
+
+func limitGenerator(data LimitBuilder) string {
+	generator := fmt.Sprintf("limit(n: %d,", data.N)
+	if data.Offset > 0 {
+		generator += fmt.Sprintf(" offset: %d", data.Offset)
+	}
+	generator += ")"
+	return generator
+}

--- a/limit_builder.go
+++ b/limit_builder.go
@@ -1,0 +1,20 @@
+package gofluxbuilder
+
+type LimitBuilder struct {
+	N      int64
+	Offset int64
+}
+
+// Validate is the validation impl of Builder for LimitBuilder
+func (f LimitBuilder) Validate() error {
+	if f.N < 0 || f.N == 0 {
+		return throwError(limitBuilderError, "provided "+
+			"N is invalid")
+	}
+	return nil
+}
+
+// Parse is the parsing impl of Builder for LimitBuilder
+func (f LimitBuilder) Parse() string {
+	return limitGenerator(f)
+}

--- a/sort_builder.go
+++ b/sort_builder.go
@@ -1,0 +1,16 @@
+package gofluxbuilder
+
+type SortBuilder struct {
+	Columns []string
+	Desc    bool
+}
+
+// Validate is the validation impl of Builder for SortBuilder
+func (f SortBuilder) Validate() error {
+	return nil
+}
+
+// Parse is the parsing impl of Builder for SortBuilder
+func (f SortBuilder) Parse() string {
+	return sortGenerator(f)
+}


### PR DESCRIPTION
This PR adds the following builders and fixes #5  :

- `sort()`
- `limit()`

The following builders can be used as below:

### Sort Builder

```go
	result, error := gofluxbuilder.NewGoFluxQueryBuilder().From(
		gofluxbuilder.FromBuilder{Bucket: "birdy"}).Range(gofluxbuilder.
		RangeBuilder{Start: "-4y"}).Filter(gofluxbuilder.NewFilterBuilder().
		Equal("_measurement", "migration")).Sort(gofluxbuilder.
		SortBuilder{Columns: []string{"hello", "nice"}}).Build()

	if error != nil {
		panic(error)
	}
	fmt.Println(result)
````

#### Result

```flux
from(bucket: "birdy", )
        |> range(start: -4y, )
        |> filter(fn: (r) => r._measurement == "migration")
        |> sort(columns: ["hello", "nice"], desc: false)
```

### Limit Builder

```go
	result, error := gofluxbuilder.NewGoFluxQueryBuilder().From(
		gofluxbuilder.FromBuilder{Bucket: "birdy"}).Range(gofluxbuilder.
		RangeBuilder{Start: "-4y"}).Filter(gofluxbuilder.NewFilterBuilder().
		Equal("_measurement", "migration")).Limit(gofluxbuilder.
			LimitBuilder{N: 4}).Build()

	if error != nil {
		panic(error)
	}
	fmt.Println(result)
````

#### Result

```flux
from(bucket: "birdy", )
        |> range(start: -4y, )
        |> filter(fn: (r) => r._measurement == "migration")
        |> limit(n: 4,)
```
