### PR TITLE
feat: add group() and count()

### DIFF
--- a/count_builder.go
+++ b/count_builder.go
@@ -1,0 +1,15 @@
+package gofluxbuilder
+
+type CountBuilder struct {
+	Column string
+}
+
+// Validate is the validation impl of Builder for MaxBuilder
+func (f CountBuilder) Validate() error {
+	return nil
+}
+
+// Parse is the parsing impl of Builder for MaxBuilder
+func (f CountBuilder) Parse() string {
+	return commonGenerator("count", f)
+}

--- a/generator.go
+++ b/generator.go
@@ -88,6 +88,26 @@ func sortGenerator(data SortBuilder) string {
 	return generator
 }
 
+func groupGenerator(data GroupBuilder) string {
+	generator := "group("
+	if len(data.Columns) > 0 {
+		generator += "columns: ["
+		for i, value := range data.Columns {
+			if i == len(data.Columns)-1 {
+				generator += fmt.Sprintf("\"%v\"", value)
+				break
+			}
+			generator += fmt.Sprintf("\"%v\", ", value)
+		}
+		generator += "], "
+		if data.Mode != "" {
+			generator += fmt.Sprintf("mode: %s", data.Mode)
+		}
+	}
+	generator += ")"
+	return generator
+}
+
 func limitGenerator(data LimitBuilder) string {
 	generator := fmt.Sprintf("limit(n: %d,", data.N)
 	if data.Offset > 0 {

--- a/gofluxbuilder.go
+++ b/gofluxbuilder.go
@@ -22,6 +22,8 @@ type Query struct {
 	Mean   Builder
 	Sort   Builder
 	Limit  Builder
+	Count  Builder
+	Group  Builder
 }
 
 // QueryBuilder is the persistent struct that allows us to hold the information
@@ -44,6 +46,7 @@ func NewGoFluxQueryBuilder() *QueryBuilder {
 		Mean:   nil,
 		Sort:   nil,
 		Limit:  nil,
+		Count:  nil,
 	}}
 }
 
@@ -75,7 +78,7 @@ func (q *QueryBuilder) Max(max ...Builder) *QueryBuilder {
 	return q
 }
 
-// Min allows to define max of flux query
+// Min allows to define min of flux query
 func (q *QueryBuilder) Min(min ...Builder) *QueryBuilder {
 	if len(min) == 0 {
 		q.query.Min = MinBuilder{}
@@ -85,7 +88,7 @@ func (q *QueryBuilder) Min(min ...Builder) *QueryBuilder {
 	return q
 }
 
-// Mean allows to define max of flux query
+// Mean allows to define mean of flux query
 func (q *QueryBuilder) Mean(mean ...Builder) *QueryBuilder {
 	if len(mean) == 0 {
 		q.query.Mean = MeanBuilder{}
@@ -95,15 +98,31 @@ func (q *QueryBuilder) Mean(mean ...Builder) *QueryBuilder {
 	return q
 }
 
-// Sort allows to define max of flux query
+// Sort allows to define sort of flux query
 func (q *QueryBuilder) Sort(sort Builder) *QueryBuilder {
 	q.query.Sort = sort
 	return q
 }
 
-// Limit allows to define max of flux query
+// Limit allows to define limit of flux query
 func (q *QueryBuilder) Limit(limit Builder) *QueryBuilder {
 	q.query.Limit = limit
+	return q
+}
+
+// Count allows to define count of flux query
+func (q *QueryBuilder) Count(mean ...Builder) *QueryBuilder {
+	if len(mean) == 0 {
+		q.query.Mean = CountBuilder{}
+		return q
+	}
+	q.query.Mean = mean[0]
+	return q
+}
+
+// Group allows to define group of flux query
+func (q *QueryBuilder) Group(group Builder) *QueryBuilder {
+	q.query.Group = group
 	return q
 }
 
@@ -167,6 +186,14 @@ func (q *QueryBuilder) Build() (string, error) {
 	if q.query.Limit != nil {
 		query += pipeGenerator()
 		query += q.query.Limit.Parse()
+	}
+	if q.query.Count != nil {
+		query += pipeGenerator()
+		query += q.query.Count.Parse()
+	}
+	if q.query.Group != nil {
+		query += pipeGenerator()
+		query += q.query.Group.Parse()
 	}
 	return query, nil
 }

--- a/group_builder.go
+++ b/group_builder.go
@@ -1,0 +1,16 @@
+package gofluxbuilder
+
+type GroupBuilder struct {
+	Columns []string
+	Mode    string
+}
+
+// Validate is the validation impl of Builder for SortBuilder
+func (f GroupBuilder) Validate() error {
+	return nil
+}
+
+// Parse is the parsing impl of Builder for SortBuilder
+func (f GroupBuilder) Parse() string {
+	return groupGenerator(f)
+}


### PR DESCRIPTION
- fixes #7 

This PR adds the following builders:

- `count()`
- `group()`


```go
	result, error := gofluxbuilder.NewGoFluxQueryBuilder().From(
		gofluxbuilder.FromBuilder{Bucket: "birdy"}).Range(gofluxbuilder.
		RangeBuilder{Start: "-4y"}).Filter(gofluxbuilder.NewFilterBuilder().
		Equal("_measurement", "migration")).Limit(gofluxbuilder.
		LimitBuilder{N: 4}).Count(gofluxbuilder.CountBuilder{Column: "gg"}).
		Group(gofluxbuilder.GroupBuilder{}).
		Build()

	if error != nil {
		panic(error)
	}
	fmt.Println(result)

```


### Result


```bash
from(bucket: "birdy", )
        |> range(start: -4y, )
        |> filter(fn: (r) => r._measurement == "migration")
        |> count(column: "gg")
        |> limit(n: 4,)
        |> group()
```