### PR TITLE
feat: sum builder

### DIFF
--- a/gofluxbuilder.go
+++ b/gofluxbuilder.go
@@ -24,6 +24,7 @@ type Query struct {
 	Limit  Builder
 	Count  Builder
 	Group  Builder
+	Sum    Builder
 }
 
 // QueryBuilder is the persistent struct that allows us to hold the information
@@ -113,7 +114,7 @@ func (q *QueryBuilder) Limit(limit Builder) *QueryBuilder {
 // Count allows to define count of flux query
 func (q *QueryBuilder) Count(mean ...Builder) *QueryBuilder {
 	if len(mean) == 0 {
-		q.query.Mean = CountBuilder{}
+		q.query.Mean = SumBuilder{}
 		return q
 	}
 	q.query.Mean = mean[0]
@@ -123,6 +124,12 @@ func (q *QueryBuilder) Count(mean ...Builder) *QueryBuilder {
 // Group allows to define group of flux query
 func (q *QueryBuilder) Group(group Builder) *QueryBuilder {
 	q.query.Group = group
+	return q
+}
+
+// Sum allows to define sum of flux query
+func (q *QueryBuilder) Sum(sum Builder) *QueryBuilder {
+	q.query.Sum = sum
 	return q
 }
 
@@ -194,6 +201,10 @@ func (q *QueryBuilder) Build() (string, error) {
 	if q.query.Group != nil {
 		query += pipeGenerator()
 		query += q.query.Group.Parse()
+	}
+	if q.query.Sum != nil {
+		query += pipeGenerator()
+		query += q.query.Sum.Parse()
 	}
 	return query, nil
 }

--- a/sum_builder.go
+++ b/sum_builder.go
@@ -1,0 +1,15 @@
+package gofluxbuilder
+
+type SumBuilder struct {
+	Column string
+}
+
+// Validate is the validation impl of Builder for SumBuilder
+func (f SumBuilder) Validate() error {
+	return nil
+}
+
+// Parse is the parsing impl of Builder for SumBuilder
+func (f SumBuilder) Parse() string {
+	return commonGenerator("sum", f)
+}


### PR DESCRIPTION
- fixes #9 

This PR adds the following builders:

- `sum()`


```go
	result, error := gofluxbuilder.NewGoFluxQueryBuilder().From(
		gofluxbuilder.FromBuilder{Bucket: "birdy"}).Range(gofluxbuilder.
		RangeBuilder{Start: "-4y"}).Filter(gofluxbuilder.NewFilterBuilder().
		Equal("_measurement", "migration")).Limit(gofluxbuilder.
		LimitBuilder{N: 4}).Count(gofluxbuilder.CountBuilder{Column: "gg"}).
		Group(gofluxbuilder.GroupBuilder{}).Sum(gofluxbuilder.SumBuilder{}).
		Build()

	if error != nil {
		panic(error)
	}
	fmt.Println(result)

```


### Result


```bash
from(bucket: "birdy", )
        |> range(start: -4y, )
        |> filter(fn: (r) => r._measurement == "migration")
        |> count(column: "gg")
        |> limit(n: 4,)
        |> group()
        |> sum()
```